### PR TITLE
Add tests for edge cases and add examples for fixing use of assert

### DIFF
--- a/test/dst-management/collected-ether-test-1.js
+++ b/test/dst-management/collected-ether-test-1.js
@@ -219,12 +219,12 @@ it('issue-apl-tokens-seria-1', function() {
         dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
 
         log("[APL] => total suply: " + dst1Total.toFixed(3) + " APL");
-        assert(1000000000000000, dst1Total);
+        assert.equal(1000000000000, dst1Total);
 
         veTokens = dstContract_APL.allowance(dstContract_APL.address,
                                           virtualExchange.address).toNumber() / 1000;
         log("[APL] => total on VirtualExchange: " + veTokens.toFixed(3) + " APL");
-        assert(1000000000000000, veTokens);
+        assert.equal(1000000000000, veTokens);
 
         return true;
     })

--- a/test/dst-management/ether-trade-funds-test-3.js
+++ b/test/dst-management/ether-trade-funds-test-3.js
@@ -1,0 +1,328 @@
+var assert = require('assert');
+
+var log = console.log;
+
+
+var Workbench = require('ethereum-sandbox-workbench');
+var workbench = new Workbench({
+  defaults: {
+    from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+  },
+
+  solcVersion: '0.4.6'
+});
+
+workbench.startTesting(['StandardToken', 'EventInfo', 'DSTContract', 'VirtualExchange', 'Wallet'],  function(contracts) {
+
+var sandbox = workbench.sandbox;
+
+// deployed contracts
+var eventInfo;
+var hackerGold;
+var virtualExchange;
+var wallet;
+
+var dstContract_APL;  // Awesome Poker League
+
+function printDate(){
+   now = eventInfo.getNow().toNumber();
+   var date = new Date(now*1000);
+
+   log('\n Date now: ' + date + '\n');
+}
+
+it('event-info-init', function() {
+
+    log('');
+    log(' *****************************');
+    log('  ether-trade-funds-test-3.js');
+    log(' *****************************');
+    log('');
+
+    return contracts.EventInfo.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            eventInfo = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+        })
+
+        .then(function() {
+
+           printDate();
+           return true;
+        });
+
+});
+
+it('wallet-init', function() {
+
+  return contracts.Wallet.new(['0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826','0xcf22908ca26c5291502432044575ea7b900bf395'],2,100)
+
+    .then(function(contract) {
+
+      if (contract.address){
+        wallet = contract;
+      } else {
+        throw new Error('No contract address');
+      }
+
+      return true;
+    });
+});
+
+
+it('hacker-gold-init', function() {
+
+    return contracts.HackerGold.new(wallet.address)
+
+        .then(function(contract) {
+
+          if (contract.address){
+            hackerGold = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+it('virtual-exchange-init', function() {
+
+    return contracts.VirtualExchange.new(hackerGold.address,
+                                         eventInfo.address)
+        .then(function(contract) {
+
+          if (contract.address){
+            virtualExchange = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+it('dst-contract-apl-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Awesome Poker League", "APL",
+
+        {
+            from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+            gas: 4000000,
+        })
+
+        .then(function(contract) {
+
+          tx = sandbox.web3.eth.getTransactionReceipt(contract.transactionHash);
+          log("Gas used: " + tx.gasUsed);
+
+          if (contract.address){
+            dstContract_APL = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+        })
+
+});
+
+it('roll-time-ve-trading-start', function() {
+
+    // Roll time to get best price on HKG,
+    // 1 Ether for 200 HKG
+    return workbench.rollTimeTo('30-Oct-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+it('issue-tokens-without-virtual-exchange', function() {
+
+  let dstTotal = dstContract_APL.getTotalSupply();
+  return dstContract_APL.issuePreferedTokens(1000, 1000000000000000,
+  {
+     from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+  })
+
+  .then(function() {
+    //Total supply should not change since APL has not yet been enlisted
+    assert.equal(dstTotal.toString(), dstContract_APL.getTotalSupply().toString());
+  });
+
+});
+
+
+it('enlist-apl', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [APL] for trading");
+
+    return virtualExchange.enlist(dstContract_APL.address,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_APL.getDSTSymbolBytes());
+
+      log("[APL] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+it('roll-time-ve-trading-start', function(){
+
+    return workbench.rollTimeTo('24-Nov-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [APL] issue tokens on [VE] balance 1,000,000,000,000.000 APL");
+
+    return dstContract_APL.issuePreferedTokens(1000, 1000000000000000,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        let dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
+
+        log("[APL] => total suply: " + dst1Total.toFixed(3) + " APL");
+        assert.equal(1000000000000, dst1Total);
+
+        let veTokens = dstContract_APL.allowance(dstContract_APL.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[APL] => total on VirtualExchange: " + veTokens.toFixed(3) + " APL");
+        assert.equal(1000000000000, veTokens);
+
+        return true;
+    })
+});
+
+it('buy-hkg-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy [HKG] for 10000 Ether");
+
+    let walletBalance = sandbox.web3.eth.getBalance(wallet.address);
+
+    return workbench.sendTransaction({
+      from: '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(500000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+          value = Math.ceil(value);
+
+          log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(75000000, value);
+
+          //Funds should have been sent to multisig wallet
+          assert(sandbox.web3.eth.getBalance(wallet.address) > walletBalance);
+          return true;
+    })
+
+});
+
+it('buy-hkg-above-safety-limit', function() {
+
+  let dstTotal = dstContract_APL.getTotalSupply();
+  let walletBalance = sandbox.web3.eth.getBalance(wallet.address);
+  let accountBalance = sandbox.web3.eth.getBalance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
+
+  return workbench.sendTransaction({
+    from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+    to: hackerGold.address,
+    value: sandbox.web3.toWei(4000000, 'ether')
+  })
+
+  .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+  })
+
+  .then(function (txHash) {
+
+        value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+        value = Math.ceil(value);
+
+        //HKG balance for 0xcd2a should be 0
+        log("[0xcd2a] => HKG balance: " + value.toFixed(3) + " HKG");
+        assert.equal(0, value);
+
+        //Total supply should not have changed
+        assert.equal(dstTotal.toString(), dstContract_APL.getTotalSupply().toString());
+
+        //Funds in multisig wallet should not have changed
+        assert.equal(sandbox.web3.eth.getBalance(wallet.address).toString(), walletBalance.toString());
+        return true;
+  })
+});
+
+it('disable-token-issue-option', function() {
+    log("");
+    log(" (!) Action: [0xcc49] disable issuance of tokens for [APL]");
+    let dstTotal;
+
+    return dstContract_APL.disableTokenIssuance(
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (parsed) {
+
+       log("");
+
+       eventName = parsed.logs[0].event;
+       assert.equal('DisableTokenIssuance', eventName);
+
+       dstTotal = dstContract_APL.getTotalSupply();
+
+    })
+
+    .then(function() {
+        //Result from this promise should be undefined, as the function is expected to throw
+        return dstContract_APL.issuePreferedTokens(1000, 1000000000000000,
+        {
+           from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+        })
+    })
+
+    .then(function() {
+      //Total supply should not change since token issuance is disabled.
+      assert.equal(dstTotal.toString(), dstContract_APL.getTotalSupply().toString());
+    });
+});
+
+});

--- a/test/dst-management/impeachment-test-3.js
+++ b/test/dst-management/impeachment-test-3.js
@@ -1,0 +1,1067 @@
+var assert = require('assert');
+
+var log = console.log;
+
+var Workbench = require('ethereum-sandbox-workbench');
+var workbench = new Workbench({
+  defaults: {
+    from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+  },
+
+  solcVersion: '0.4.6'
+});
+
+workbench.startTesting(['StandardToken', 'EventInfo', 'DSTContract', 'VirtualExchange'],  function(contracts) {
+
+var sandbox = workbench.sandbox;
+
+// deployed contracts
+var eventInfo;
+var hackerGold;
+var virtualExchange;
+
+var dstContract_APL;  // Awesome Poker League
+
+function printDate(){
+   now = eventInfo.getNow().toNumber();
+   var date = new Date(now*1000);
+
+   log('\n Date now: ' + date + '\n');
+}
+
+
+/**
+ *
+ * Testing for impeachment:
+ *
+ * 1. Voting structure 30%, 30%, 30%, 10%
+ * 2. Submit impeachment proposal
+ * 3. Support the impeachment proposal by 70%
+ *
+ */
+
+it('event-info-init', function() {
+
+    log('');
+    log(' ***********************');
+    log('  impeachment-test-3.js ');
+    log(' ***********************');
+    log('');
+
+    return contracts.EventInfo.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            eventInfo = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+        })
+
+        .then(function() {
+
+           printDate();
+           return true;
+        });
+
+});
+
+
+it('hacker-gold-init', function() {
+
+    return contracts.HackerGold.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            hackerGold = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    // Roll time to get best price on HKG,
+    // 1 Ether for 200 HKG
+    return workbench.rollTimeTo('30-Oct-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('buy-hkg-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy [HKG] for 10000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+          log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy [HKG] for 10,000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+          log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+          log("[0x696b] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+          log("[0xcd2a] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    return workbench.rollTimeTo('24-Nov-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+
+it('virtual-exchange-init', function() {
+
+    return contracts.VirtualExchange.new(hackerGold.address,
+                                         eventInfo.address)
+        .then(function(contract) {
+
+          if (contract.address){
+            virtualExchange = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+it('dst-contract-apl-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Awesome Poker League", "APL",
+
+        {
+            from : '0xcc49bea5129ef2369ff81b0c0200885893979b77'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_APL = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('enlist-apl', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [APL] for trading");
+
+    return virtualExchange.enlist(dstContract_APL.address,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_APL.getDSTSymbolBytes());
+
+      log("[APL] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [APL] issue tokens on [VE] balance 1,000,000,000,000.000 APL");
+
+    return dstContract_APL.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
+
+        log("[APL] => total suply: " + dst1Total.toFixed(3) + " APL");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_APL.allowance(dstContract_APL.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[APL] => total on VirtualExchange: " + veTokens.toFixed(3) + " APL");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] move to [VE] balance 2,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0xcd2a] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('buy-apl-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+        assert.equal(300000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+        assert.equal(700000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-apl-by-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(50, voting / total * 100);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(50, voting / total * 100);
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(600000, value);
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-apl-by-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x696b] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x696b] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x696b] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + (voting / total * 100).toFixed(2) + "%");
+        assert.equal(33.33, (voting / total * 100).toFixed(2));
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + (voting / total * 100).toFixed(2) + "%");
+        assert.equal(33.33, (voting / total * 100).toFixed(2));
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x696b] => voting: " + voting + " votes - " + (voting / total * 100).toFixed(2) + "%");
+        assert.equal(33.33, (voting / total * 100).toFixed(2));
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(900000, value);
+
+        return true;
+    })
+});
+
+
+
+it('buy-apl-by-cd2a', function() {
+    log("");
+    log(" (!) Action: [cd2a] buy tokens [APL] for 100,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 100000000,
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+        log("[0xcd2a] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(100000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
+
+        log ("[0xcd2a] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(100000000000 , voting);
+
+        value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+        log("[0xcd2a] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1900000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0xcd2a] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1900000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + (voting / total * 100) + "%");
+        assert.equal(30, (voting / total * 100).toFixed(2));
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + (voting / total * 100) + "%");
+        assert.equal(30, (voting / total * 100).toFixed(2));
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x696b] => voting: " + voting + " votes - " + (voting / total * 100) + "%");
+        assert.equal(30, (voting / total * 100).toFixed(2));
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
+
+        log ("[0xcd2a] => voting: " + voting + " votes - " + (voting / total * 100) + "%");
+        assert.equal(10, (voting / total * 100).toFixed(2));
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(1000000, value);
+
+        return true;
+    })
+});
+
+
+it('roll-time-va-ends', function(){
+
+    return workbench.rollTimeTo('22-Dec-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('roll-time-50%-available', function(){
+
+    return workbench.rollTimeTo('22-Feb-2017 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+it('submit-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0xcc49] ask to recieve 200,000.000 (20%) of the HKG collected");
+
+    return dstContract_APL.submitHKGProposal(200000000, "http://pastebin.com/raw/6e9PBTeP",
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       args = parsed.logs[0].args;
+
+       proposalId = args.id;
+       proposalValue = args.value;
+       proposalValue = proposalValue / 1000;
+
+       proposalTimeEnds = args.timeEnds;
+       proposalURL = args.url;
+       proposalSender = args.sender;
+
+       log("");
+       log("Proposal Submitted");
+       log("==================");
+
+       log("proposalId: "       + proposalId);
+       log("proposalValue: "    + proposalValue.toFixed(3));
+       log("proposalTimeEnds: " + proposalTimeEnds);
+       log("proposalURL: "      + proposalURL);
+       log("proposalSender: "   + proposalSender);
+
+
+       assert.equal(200000, proposalValue);
+
+       t1 = eventInfo.getNow().toNumber() + 60 * 60 * 24 * 10;
+       t2 = proposalTimeEnds;
+       assert.equal(t1, t2);
+
+       assert.equal(proposalURL,    "http://pastebin.com/raw/6e9PBTeP");
+       assert.equal(proposalSender, "0xcc49bea5129ef2369ff81b0c0200885893979b77");
+
+       proposal_1 = proposalId;
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(0, value);
+
+       return true;
+    })
+
+});
+
+
+
+it('object-by-vote-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] vote to object proposal 1");
+
+    return dstContract_APL.objectProposal(proposal_1,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       log_1 = parsed.logs[0];
+
+       total  = dstContract_APL.getPreferedQtySold();
+
+       log("\n");
+       log(log_1.event + ":");
+       log("============");
+
+       log("proposal.id: " + log_1.args.id);
+       log("voter: " + log_1.args.voter);
+       log("votes: " + log_1.args.votes + " share: " + (log_1.args.votes / total * 100).toFixed(2) + "%");
+
+       voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber();
+
+       assert.equal(proposal_1, log_1.args.id);
+       assert.equal(log_1.args.voter, "0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d");
+       assert.equal(log_1.args.votes, voting);
+
+       return true;
+    })
+
+});
+
+
+it('roll-time-proposal-redeem', function(){
+
+    return workbench.rollTimeTo('04-Mar-2017 14:01 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('redeem-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0xcc49] collect 1,000.000 HKG value of proposal 1");
+
+    return dstContract_APL.redeemProposalFunds(proposal_1,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(1, parsed.logs.length);
+
+       args = parsed.logs[0].args;
+
+       assert.equal(dstContract_APL.address, args.from);
+       assert.equal("0xcc49bea5129ef2369ff81b0c0200885893979b77", args.to);
+       assert.equal(200000000, args.value);
+
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(200000, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(800000, value);
+
+       return true;
+    })
+
+});
+
+
+
+it('roll-time-to-start-impeachment', function(){
+    return workbench.rollTimeTo('22-Mar-2017 14:02 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+it('impeachment-proposal-submit-1', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] submit impeachment proposal");
+
+    return dstContract_APL.submitImpeachmentProposal("http://pastebin.com/raw/Ehet8yVf", '0xdedb49385ad5b94a16f236a6890cf9e0b1e30392',
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas : 250000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       args = parsed.logs[0].args;
+
+       log("");
+
+       log("ImpeachmentProposed (event)");
+       log("===================");
+
+
+       assert.equal("ImpeachmentProposed", parsed.logs[0].event);
+
+       log("Submited by: " +  args.submitter);
+       assert.equal("0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d", args.submitter);
+
+       assert.equal("http://pastebin.com/raw/Ehet8yVf",           args.urlDetails);
+       assert.equal("0xdedb49385ad5b94a16f236a6890cf9e0b1e30392", args.newExecutive);
+
+       expectedEndTime = new Date('05-Apr-2017 14:02 UTC+00').getTime() / 1000;
+       assert.equal(Math.floor(expectedEndTime / 60), Math.floor(args.votindEndTS / 60)); // seconds can be different
+
+       return true;
+    })
+
+    .then(function () {
+
+       totalPreferred = dstContract_APL.getPreferedQtySold().toNumber();
+       impeachmentSupport = dstContract_APL.getCurrentImpeachmentVotesSupporting().toNumber();
+
+       impSupport = (impeachmentSupport / totalPreferred) * 100
+
+       log("");
+
+       log("Support for impeachment: " + impSupport + "%");
+       assert.equal(30, impSupport);
+
+       log("Executive for now: " + dstContract_APL.getExecutive());
+       assert.equal('0xcc49bea5129ef2369ff81b0c0200885893979b77' ,dstContract_APL.getExecutive());
+
+       return true;
+    })
+
+});
+
+
+it('impeachment-proposal-support-1', function() {
+    log("");
+    log(" (!) Action: [0x2980] support impeachment proposal");
+
+    return dstContract_APL.supportImpeachment(
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+       gas : 250000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       args = parsed.logs[0].args;
+
+       log("");
+
+       log("ImpeachmentSupport (event)");
+       log("==================");
+
+       assert.equal("ImpeachmentSupport", parsed.logs[0].event);
+
+       log("Submited by: " +  args.supportter);
+       assert.equal("0x29805ff5b946e7a7c5871c1fb071f740f767cf41", args.supportter);
+
+       log("[0x2980] submited " + args.votes + " votes");
+       assert.equal(300000000000, args.votes.toNumber());
+
+       return true;
+    })
+
+    .then(function () {
+
+       totalPreferred = dstContract_APL.getPreferedQtySold().toNumber();
+       impeachmentSupport = dstContract_APL.getCurrentImpeachmentVotesSupporting().toNumber();
+
+       impSupport = (impeachmentSupport / totalPreferred) * 100
+
+       log("");
+
+       log("Support for impeachment: " + impSupport + "%");
+       assert.equal(60, impSupport);
+
+       log("Executive for now: " + dstContract_APL.getExecutive());
+       assert.equal('0xcc49bea5129ef2369ff81b0c0200885893979b77' ,dstContract_APL.getExecutive());
+
+       return true;
+    })
+});
+
+
+
+it('impeachment-proposal-support-2', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] support impeachment proposal");
+
+    return dstContract_APL.supportImpeachment(
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+       gas : 250000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       args = parsed.logs[0].args;
+
+       log("");
+
+       log("ImpeachmentSupport (event)");
+       log("==================");
+
+       assert.equal("ImpeachmentSupport", parsed.logs[0].event);
+
+       log("Submited by: " +  args.supportter);
+       assert.equal("0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826", args.supportter);
+
+       log("[0x2980] submited " + args.votes + " votes");
+       assert.equal(100000000000, args.votes.toNumber());
+
+       return true;
+    })
+
+    .then(function () {
+
+       totalPreferred = dstContract_APL.getPreferedQtySold().toNumber();
+       impeachmentSupport = dstContract_APL.getCurrentImpeachmentVotesSupporting().toNumber();
+
+       impSupport = (impeachmentSupport / totalPreferred) * 100
+
+       log("");
+
+       log("Support for impeachment: " + impSupport + "%");
+       assert.equal(70, impSupport);
+
+       log("Executive for now: " + dstContract_APL.getExecutive());
+       assert.equal('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392' ,dstContract_APL.getExecutive());
+
+       return true;
+    })
+
+});
+
+
+
+
+});

--- a/test/dst-management/initiate-tokens-test-4.js
+++ b/test/dst-management/initiate-tokens-test-4.js
@@ -1,0 +1,1527 @@
+var assert = require('assert');
+
+var log = console.log;
+
+var Workbench = require('ethereum-sandbox-workbench');
+var workbench = new Workbench({
+  defaults: {
+    from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+  },
+
+  solcVersion: '0.4.6'
+});
+
+workbench.startTesting(['StandardToken', 'EventInfo', 'DSTContract', 'VirtualExchange'],  function(contracts) {
+
+var sandbox = workbench.sandbox;
+
+// deployed contracts
+var eventInfo;
+var hackerGold;
+var virtualExchange;
+
+var dstContract_APL;  // Awesome Poker League
+var dstContract_FBX;  // Filmbox
+var dstContract_GOG;  // Gog and Magog
+var dstContract_AMZ;  // Auto Motor Zone
+
+function printDate(){
+   now = eventInfo.getNow().toNumber();
+   var date = new Date(now*1000);
+
+   log('\n Date now: ' + date + '\n');
+}
+
+
+/**
+ *
+ * Testing for issue project token series:
+ *
+ *     1.
+ *     2.
+ *     3.
+ *
+ *    ... todo detailed description
+ */
+
+it('event-info-init', function() {
+
+
+    log('');
+    log(' ***************************');
+    log('  initiate-tokens-test-4.js ');
+    log(' ***************************');
+    log('');
+
+
+    return contracts.EventInfo.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            eventInfo = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+        })
+
+        .then(function() {
+
+           printDate();
+           return true;
+        });
+
+});
+
+
+it('hacker-gold-init', function() {
+
+    return contracts.HackerGold.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            hackerGold = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    // Roll time to get best price on HKG,
+    // 1 Ether for 200 HKG
+    return workbench.rollTimeTo('30-Oct-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('buy-hkg-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy [HKG] for 10000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+          log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy [HKG] for 10,000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+          log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+          log("[0x696b] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+          log("[0xcd2a] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    return workbench.rollTimeTo('24-Nov-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+
+it('virtual-exchange-init', function() {
+
+    return contracts.VirtualExchange.new(hackerGold.address,
+                                         eventInfo.address)
+        .then(function(contract) {
+
+          if (contract.address){
+            virtualExchange = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+it('dst-contract-apl-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Awesome Poker League", "APL",
+
+        {
+            from : '0xcc49bea5129ef2369ff81b0c0200885893979b77'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_APL = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+it('dst-contract-fbx-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Filmbox", "FBX",
+
+        {
+            from : '0xcf22908ca26c5291502432044575ea7b900bf395'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_FBX = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('dst-contract-gog-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Gog and Magog", "GOG",
+
+        {
+            from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_GOG = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+it('dst-contract-amz-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Gog and Maamz", "AMZ",
+
+        {
+            from : '0xdb5918d9282f0b280aac6bde061b92e903e11d18'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_AMZ = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('enlist-apl', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [APL] for trading");
+
+    return virtualExchange.enlist(dstContract_APL.address,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_APL.getDSTSymbolBytes());
+
+      log("[APL] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+it('enlist-fbx', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [FBX] for trading");
+
+    return virtualExchange.enlist(dstContract_FBX.address,
+    {
+       from : '0xcf22908ca26c5291502432044575ea7b900bf395',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_FBX.getDSTSymbolBytes());
+
+      log("[FBX] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+it('enlist-gog', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [GOG] for trading");
+
+    return virtualExchange.enlist(dstContract_GOG.address,
+    {
+       from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_GOG.getDSTSymbolBytes());
+
+      log("[GOG] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+
+it('enlist-amz', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [AMZ] for trading");
+
+    return virtualExchange.enlist(dstContract_AMZ.address,
+    {
+       from : '0xdb5918d9282f0b280aac6bde061b92e903e11d18',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_AMZ.getDSTSymbolBytes());
+
+      log("[AMZ] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [APL] issue tokens on [VE] balance 1,000,000,000,000.000 APL");
+
+    return dstContract_APL.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
+
+        log("[APL] => total suply: " + dst1Total.toFixed(3) + " APL");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_APL.allowance(dstContract_APL.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[APL] => total on VirtualExchange: " + veTokens.toFixed(3) + " APL");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('issue-fbx-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [FBX] issue tokens on [VE] balance 1,000,000,000,000.000 FBX");
+
+    return dstContract_FBX.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xcf22908ca26c5291502432044575ea7b900bf395',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_FBX.getTotalSupply().toNumber() / 1000;
+
+        log("[FBX] => total suply: " + dst1Total.toFixed(3) + " FBX");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_FBX.allowance(dstContract_FBX.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[FBX] => total on VirtualExchange: " + veTokens.toFixed(3) + " FBX");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('issue-gog-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [GOG] issue tokens on [VE] balance 1,000,000,000,000.000 GOG");
+
+    return dstContract_GOG.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_GOG.getTotalSupply().toNumber() / 1000;
+
+        log("[GOG] => total suply: " + dst1Total.toFixed(3) + " GOG");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_GOG.allowance(dstContract_GOG.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[GOG] => total on VirtualExchange: " + veTokens.toFixed(3) + " GOG");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+
+it('issue-amz-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [AMZ] issue tokens on [VE] balance 1,000,000,000,000.000 AMZ");
+
+    return dstContract_AMZ.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xdb5918d9282f0b280aac6bde061b92e903e11d18',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_AMZ.getTotalSupply().toNumber() / 1000;
+
+        log("[AMZ] => total suply: " + dst1Total.toFixed(3) + " AMZ");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_AMZ.allowance(dstContract_AMZ.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[AMZ] => total on VirtualExchange: " + veTokens.toFixed(3) + " AMZ");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] move to [VE] balance 2,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0xcd2a] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('buy-apl-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+        assert.equal(300000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+        assert.equal(700000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [APL] price change to 0.5 APL for 1 HKG ");
+
+    return dstContract_APL.setHKGPrice(500,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        qtyForOneHkg = dstContract_APL.getHKGPrice().toNumber() / 1000;
+
+        log("[APL] => price 1 HKG = " + qtyForOneHkg + " APL");
+
+
+        //...todo check the event
+
+        return true;
+    })
+});
+
+
+
+// ...
+// [X] Action: [APL] price change by mal actor.
+// ...
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" [X] Action: [APL] price change by mal actor ");
+
+    return dstContract_APL.setHKGPrice(50000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+    })
+
+    .then(function () {
+
+        qtyForOneHkg = dstContract_APL.getHKGPrice().toNumber() / 1000;
+
+        log("[APL] => price 1 HKG = " + qtyForOneHkg + " APL");
+
+        return true;
+    })
+});
+
+
+
+it('buy-apl-by-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy tokens [APL] for 1,400,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 1400000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(700000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(700000000000 , voting);
+
+        value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(600000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(600000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(30, voting / total * 100);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(70, voting / total * 100);
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-fbx-by-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy tokens [FBX] for 480,000.000 HKG");
+
+
+    return virtualExchange.buy('FBX', 480000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_FBX.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " FBX");
+        assert.equal(480000000 , dst1Balance);
+
+        total  = dstContract_FBX.getPreferedQtySold();
+        voting = dstContract_FBX.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(480000000000 , voting);
+
+        value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1520000, value);
+
+        log ("[FBX] => total: " + total + " votes");
+        assert.equal(480000000000, total);
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1520000 , veTokens);
+
+        availableSuply = dstContract_FBX.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+        log("[FBX] => available suply: " + availableSuply + " FBX");
+        assert.equal(520000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+it('buy-fbx-by-0xcd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] buy tokens [FBX] for 520,000.000 HKG");
+
+
+    return virtualExchange.buy('FBX', 520000000,
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_FBX.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " FBX");
+        assert.equal(520000000 , dst1Balance);
+
+        total  = dstContract_FBX.getPreferedQtySold();
+        voting = dstContract_FBX.votingRightsOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(520000000000 , voting);
+
+        value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1480000, value);
+
+        log ("[FBX] => total: " + total + " votes");
+        assert.equal(1000000000000, total);
+
+        veTokens = hackerGold.allowance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1480000 , veTokens);
+
+        availableSuply = dstContract_FBX.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+        log("[FBX] => available suply: " + availableSuply + " FBX");
+        assert.equal(0 , availableSuply);
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_FBX.getPreferedQtySold();
+        voting = dstContract_FBX.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(48, voting / total * 100);
+
+        total  = dstContract_FBX.getPreferedQtySold();
+        voting = dstContract_FBX.votingRightsOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(52, voting / total * 100);
+
+        value = hackerGold.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+        log("[FBX] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(1000000, value);
+
+        return true;
+    })
+});
+
+
+it('buy-gog-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [GOG] for 100,000.000 HKG");
+
+
+    return virtualExchange.buy('GOG', 100000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_GOG.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " GOG");
+        assert.equal(100000000 , dst1Balance);
+
+        total  = dstContract_GOG.getPreferedQtySold();
+        voting = dstContract_GOG.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(100000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1600000, value);
+
+        log ("[GOG] => total: " + total + " votes");
+        assert.equal(100000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1600000 , veTokens);
+
+        availableSuply = dstContract_GOG.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+        log("[GOG] => available suply: " + availableSuply + " GOG");
+        assert.equal(900000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+it('change-price-gog-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [GOG] price change to 2 GOG for 1 HKG ");
+
+    return dstContract_GOG.setHKGPrice(2000,
+    {
+       from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f',
+    })
+
+    .then(function () {
+
+        qtyForOneHkg = dstContract_GOG.getHKGPrice().toNumber() / 1000;
+
+        log("[GOG] => price 1 HKG = " + qtyForOneHkg + " GOG");
+        assert.equal(2, qtyForOneHkg.toFixed(3));
+
+        //...todo check the event
+
+        return true;
+    })
+});
+
+
+it('buy-gog-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [GOG] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('GOG', 300000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_GOG.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " GOG");
+        assert.equal(700000000 , dst1Balance);
+
+        total  = dstContract_GOG.getPreferedQtySold();
+        voting = dstContract_GOG.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(700000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1300000, value);
+
+        log ("[GOG] => total: " + total + " votes");
+        assert.equal(700000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1300000 , veTokens);
+
+        availableSuply = dstContract_GOG.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+        log("[GOG] => available suply: " + availableSuply + " GOG");
+        assert.equal(300000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+it('change-price-gog-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [GOG] price change to 1 GOG for 1 HKG ");
+
+    return dstContract_GOG.setHKGPrice(1000,
+    {
+       from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f',
+    })
+
+    .then(function () {
+
+        qtyForOneHkg = dstContract_GOG.getHKGPrice().toNumber() / 1000;
+
+        log("[GOG] => price 1 HKG = " + qtyForOneHkg + " GOG");
+        assert.equal(1, qtyForOneHkg.toFixed(3));
+
+        //...todo check the event
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-gog-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [GOG] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('GOG', 300000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_GOG.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " GOG");
+        assert.equal(1000000000 , dst1Balance);
+
+        total  = dstContract_GOG.getPreferedQtySold();
+        voting = dstContract_GOG.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(1000000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1000000, value);
+
+        log ("[GOG] => total: " + total + " votes");
+        assert.equal(1000000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1000000 , veTokens);
+
+        availableSuply = dstContract_GOG.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+        log("[GOG] => available suply: " + availableSuply + " GOG");
+        assert.equal(0 , availableSuply);
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_GOG.getPreferedQtySold();
+        voting = dstContract_GOG.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(100, voting / total * 100);
+
+
+
+
+        return true;
+    })
+});
+
+
+
+it('roll-time-va-ends', function(){
+
+    return workbench.rollTimeTo('22-Dec-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+
+it('end-event-summary', function() {
+    log("");
+
+    //var dstContract_APL;  // Awesome Poker League
+    //var dstContract_FBX;  // Filmbox
+    //var dstContract_GOG;  // Gog and Magog
+    //var dstContract_AMZ;  // Auto Motor Zone
+
+    log("Post Event Summary:");
+    log("===================");
+
+    value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[APL] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(17000, dollarValue);
+
+    value = hackerGold.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[FBX] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(10000, dollarValue);
+
+    value = hackerGold.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[GOG] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(7000, dollarValue);
+
+
+    value = hackerGold.balanceOf(dstContract_AMZ.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[AMZ] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(0, dollarValue);
+
+
+    return true;
+});
+
+
+
+
+it('issue-apl-tokens-seria-2', function() {
+    log("");
+    log(" (!) Action: [APL] issue tokens: 1000000.000 APL");
+
+    return dstContract_APL.issueTokens(100, 1000000000,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
+        log("[APL] => total: " + dst1Total.toFixed(3) + " APL");
+        assert.equal(1001000000 , dst1Total);
+
+        issued = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + issued.toFixed(3) + " APL");
+        assert.equal(1000000 , issued);
+
+        return true;
+    })
+});
+
+
+
+it('issue-fbx-tokens-seria-2', function() {
+    log("");
+    log(" (!) Action: [FBX] issue tokens: 1000000.000 FBX");
+
+    return dstContract_FBX.issueTokens(20, 1000000000,
+    {
+       from : '0xcf22908ca26c5291502432044575ea7b900bf395',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_FBX.getTotalSupply().toNumber() / 1000;
+        log("[FBX] => total: " + dst1Total.toFixed(3) + " FBX");
+        assert.equal(1001000000 , dst1Total);
+
+        issued = dstContract_FBX.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+        log("[FBX] => available suply: " + issued.toFixed(3) + " FBX");
+        assert.equal(1000000 , issued);
+
+        return true;
+    })
+});
+
+
+
+it('issue-gog-tokens-seria-2', function() {
+    log("");
+    log(" (!) Action: [GOG] issue tokens: 1000000.000 GOG");
+
+    return dstContract_GOG.issueTokens(250, 1000000000,
+    {
+       from : '0xba33cc5dd6a60c891bcf93fbac8f13ee7512435f',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_GOG.getTotalSupply().toNumber() / 1000;
+        log("[GOG] => total: " + dst1Total.toFixed(3) + " GOG");
+        assert.equal(1001000000 , dst1Total);
+
+        issued = dstContract_GOG.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+        log("[GOG] => available suply: " + issued.toFixed(3) + " GOG");
+        assert.equal(1000000 , issued);
+
+        return true;
+    })
+});
+
+
+
+
+
+it('buy-all-apl-suply-seria-2', function() {
+    log("");
+    log(" (!) Action: [0xdedb] buy [APL] tokens for: 10000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xdedb49385ad5b94a16f236a6890cf9e0b1e30392',
+      to: dstContract_APL.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+        dst1Total = dstContract_APL.balanceOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392').toNumber() / 1000;
+        log("[0xdedb] => balance: " + dst1Total + " APL");
+        assert.equal(1000000 , dst1Total);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392');
+
+        log("[0xdedb] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(0, voting / total * 100);
+
+        tokensSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber();
+        log("[APL] => available suply: " + tokensSuply + " APL");
+        assert.equal(0, tokensSuply);
+
+        log("");
+
+        etherCollected =
+          dstContract_APL.getEtherValue().toNumber() / 1000000000000000000;
+        log("[APL] => balance: " + etherCollected + " Ether");
+        assert.equal(10000, etherCollected);
+
+        hkgCollected = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected balance: " + hkgCollected.toFixed(3) + " HKG");
+        assert.equal(1700000, hkgCollected);
+
+        return true;
+    })
+
+});
+
+
+
+
+
+
+
+it('buy-all-fbx-suply-seria-2', function() {
+    log("");
+    log(" (!) Action: [0xdedb] buy [FBX] tokens for: 50000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xdedb49385ad5b94a16f236a6890cf9e0b1e30392',
+      to: dstContract_FBX.address,
+      value: sandbox.web3.toWei(50001, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+        dst1Total = dstContract_FBX.balanceOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392').toNumber() / 1000;
+        dst1Total = Math.ceil(dst1Total);
+
+        log("[0xdedb] => balance: " + dst1Total + " FBX");
+        assert.equal(1000000 , dst1Total);
+
+        total  = dstContract_FBX.getPreferedQtySold();
+        voting = dstContract_FBX.votingRightsOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392');
+
+        log("[0xdedb] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(0, voting / total * 100);
+
+        tokensSuply = dstContract_FBX.balanceOf(dstContract_FBX.address).toNumber();
+        log("[FBX] => available suply: " + tokensSuply + " FBX");
+        assert.equal(0, tokensSuply);
+
+        log("");
+
+        etherCollected =
+          dstContract_FBX.getEtherValue().toNumber() / 1000000000000000000;
+        etherCollected = Math.ceil(etherCollected)
+        log("[FBX] => balance: " + etherCollected + " Ether");
+
+        assert.equal(50000, etherCollected);
+
+        hkgCollected = hackerGold.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+        log("[FBX] => collected balance: " + hkgCollected.toFixed(3) + " HKG");
+        assert.equal(1000000, hkgCollected);
+
+        return true;
+    })
+
+});
+
+
+
+
+it('buy-all-gog-suply-seria-2', function() {
+    log("");
+    log(" (!) Action: [0xdedb] buy [GOG] tokens for: 4000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xdedb49385ad5b94a16f236a6890cf9e0b1e30392',
+      to: dstContract_GOG.address,
+      value: sandbox.web3.toWei(4000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+        dst1Total = dstContract_GOG.balanceOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392').toNumber() / 1000;
+        dst1Total = Math.ceil(dst1Total);
+
+        log("[0xdedb] => balance: " + dst1Total + " GOG");
+        assert.equal(1000000 , dst1Total);
+
+        total  = dstContract_GOG.getPreferedQtySold();
+        voting = dstContract_GOG.votingRightsOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392');
+
+        log("[0xdedb] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(0, voting / total * 100);
+
+        tokensSuply = dstContract_GOG.balanceOf(dstContract_GOG.address).toNumber();
+        log("[GOG] => available suply: " + tokensSuply + " GOG");
+        assert.equal(0, tokensSuply);
+
+        log("");
+
+        etherCollected =
+          dstContract_GOG.getEtherValue().toNumber() / 1000000000000000000;
+        etherCollected = Math.ceil(etherCollected)
+        log("[GOG] => balance: " + etherCollected + " Ether");
+
+        assert.equal(4000, etherCollected);
+
+        hkgCollected = hackerGold.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+        log("[GOG] => collected balance: " + hkgCollected.toFixed(3) + " HKG");
+        assert.equal(700000, hkgCollected);
+
+        return true;
+    })
+
+});
+
+
+
+it('end-sale-summary', function() {
+    log("");
+
+    //var dstContract_APL;  // Awesome Poker League
+    //var dstContract_FBX;  // Filmbox
+    //var dstContract_GOG;  // Gog and Magog
+    //var dstContract_AMZ;  // Auto Motor Zone
+
+    log("Post Event Summary:");
+    log("===================");
+
+    value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[APL] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(17000, dollarValue);
+
+    etherCollected =
+          dstContract_APL.getEtherValue().toNumber() / 1000000000000000000;
+    log("[APL] => collected: " + etherCollected + " Ether" + " = $" + etherCollected * 12);
+    assert.equal(10000, etherCollected);
+
+    log("");
+
+    value = hackerGold.balanceOf(dstContract_FBX.address).toNumber() / 1000;
+
+    dollarValue = value / 100;
+    log("[FBX] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(10000, dollarValue);
+
+    value = hackerGold.balanceOf(dstContract_GOG.address).toNumber() / 1000;
+
+    etherCollected =
+          dstContract_FBX.getEtherValue().toNumber() / 1000000000000000000;
+    etherCollected = Math.ceil(etherCollected);
+
+    log("[FBX] => collected: " + etherCollected + " Ether" + " = $" + etherCollected * 12);
+    assert.equal(50000, etherCollected);
+
+    log("");
+
+    dollarValue = value / 100;
+    log("[GOG] => collected: " + value.toFixed(3) + " HKG" + " = $" + dollarValue);
+    assert.equal(7000, dollarValue);
+
+    etherCollected =
+          dstContract_GOG.getEtherValue().toNumber() / 1000000000000000000;
+    etherCollected = Math.ceil(etherCollected);
+
+    log("[GOG] => collected: " + etherCollected + " Ether" + " = $" + etherCollected * 12);
+    assert.equal(4000, etherCollected);
+
+    return true;
+});
+
+
+
+});

--- a/test/dst-management/requesting-funds-test-5.js
+++ b/test/dst-management/requesting-funds-test-5.js
@@ -1,0 +1,1153 @@
+var assert = require('assert');
+
+var log = console.log;
+
+var Workbench = require('ethereum-sandbox-workbench');
+var workbench = new Workbench({
+  defaults: {
+    from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+  },
+
+  solcVersion: '0.4.6'
+});
+
+workbench.startTesting(['StandardToken', 'EventInfo', 'DSTContract', 'VirtualExchange'],  function(contracts) {
+
+var sandbox = workbench.sandbox;
+
+// deployed contracts
+var eventInfo;
+var hackerGold;
+var virtualExchange;
+
+var dstContract_APL;  // Awesome Poker League
+
+function printDate(){
+   now = eventInfo.getNow().toNumber();
+   var date = new Date(now*1000);
+
+   log('\n Date now: ' + date + '\n');
+}
+
+
+/**
+ *
+ * Testing for issue project token series:
+ *
+ *     1. Create structure of DST 30% / 30% / 40% - owners
+ *     2. Object 1st proposal by 30% => the proposal is go through
+ *     3. Object 2st proposal by 70% => the proposal is rejected
+ *     4. Roll 6 months and collect all the funds.
+ *
+ */
+
+it('event-info-init', function() {
+
+    log('');
+    log(' *****************************');
+    log('  requesting-funds-test-5.js  ');
+    log(' *****************************');
+    log('');
+
+    return contracts.EventInfo.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            eventInfo = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+        })
+
+        .then(function() {
+
+           printDate();
+           return true;
+        });
+
+});
+
+
+it('hacker-gold-init', function() {
+
+    return contracts.HackerGold.new()
+
+        .then(function(contract) {
+
+          if (contract.address){
+            hackerGold = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    // Roll time to get best price on HKG,
+    // 1 Ether for 200 HKG
+    return workbench.rollTimeTo('30-Oct-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('buy-hkg-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy [HKG] for 10000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+          log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy [HKG] for 10,000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+          log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+          log("[0x696b] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+it('buy-hkg-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] buy [HKG] for 5000.000 Ether");
+
+    return workbench.sendTransaction({
+      from: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+      to: hackerGold.address,
+      value: sandbox.web3.toWei(10000, 'ether')
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (txHash) {
+
+          value = hackerGold.balanceOf('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826').toNumber() / 1000;
+
+          log("[0xcd2a] => balance: " + value.toFixed(3) + " HKG");
+          assert.equal(2000000, value);
+
+          return true;
+    })
+
+});
+
+
+
+it('roll-time-ve-trading-start', function(){
+
+    return workbench.rollTimeTo('24-Nov-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+
+it('virtual-exchange-init', function() {
+
+    return contracts.VirtualExchange.new(hackerGold.address,
+                                         eventInfo.address)
+        .then(function(contract) {
+
+          if (contract.address){
+            virtualExchange = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+it('dst-contract-apl-init', function() {
+
+    return contracts.DSTContract.new(eventInfo.address, hackerGold.address, "Awesome Poker League", "APL",
+
+        {
+            from : '0xcc49bea5129ef2369ff81b0c0200885893979b77'
+        })
+
+        .then(function(contract) {
+
+          if (contract.address){
+            dstContract_APL = contract;
+          } else {
+            throw new Error('No contract address');
+          }
+
+          return true;
+    });
+});
+
+
+
+it('enlist-apl', function() {
+    log("");
+    log(" (!) Action: [VE] enlist [APL] for trading");
+
+    return virtualExchange.enlist(dstContract_APL.address,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+   .then(function(txHash) {
+
+      // we are waiting for blockchain to accept the transaction
+      return workbench.waitForReceipt(txHash);
+    })
+
+   .then(function() {
+
+      exist = virtualExchange.isExistByBytes(dstContract_APL.getDSTSymbolBytes());
+
+      log("[APL] => enlisted: " + exist);
+      assert.equal(true, exist);
+
+      return true;
+    })
+
+});
+
+
+it('issue-apl-tokens-seria-1', function() {
+    log("");
+    log(" (!) Action: [APL] issue tokens on [VE] balance 1,000,000,000,000.000 APL");
+
+    return dstContract_APL.issuePreferedTokens(1000, 1000000000000,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+    })
+
+    .then(function () {
+
+        dst1Total = dstContract_APL.getTotalSupply().toNumber() / 1000;
+
+        log("[APL] => total suply: " + dst1Total.toFixed(3) + " APL");
+        assert.equal(1000000000, dst1Total);
+
+        veTokens = dstContract_APL.allowance(dstContract_APL.address,
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[APL] => total on VirtualExchange: " + veTokens.toFixed(3) + " APL");
+        assert.equal(1000000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] move to [VE] balance 2,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('approve-hkg-spend-on-exchange-for-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+
+it('approve-hkg-spend-on-exchange-for-cd2a', function() {
+    log("");
+    log(" (!) Action: [0xcd2a] move to [VE] balance 1,000,000.000 HKG");
+
+    return hackerGold.approve(virtualExchange.address, 2000000000,
+    {
+       from : '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        veTokens = hackerGold.allowance('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
+                                          virtualExchange.address).toNumber() / 1000;
+
+        log("[0xcd2a] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(2000000, veTokens);
+
+        return true;
+    })
+});
+
+
+it('buy-apl-by-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber() / 1000;
+
+        log("[0x3a7e] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+        assert.equal(300000000000, total);
+
+        veTokens = hackerGold.allowance('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x3a7e] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+        assert.equal(700000000 , availableSuply);
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-apl-by-2980', function() {
+    log("");
+    log(" (!) Action: [0x2980] buy tokens [APL] for 300,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 300000000,
+    {
+       from : '0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(300000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(300000000000 , voting);
+
+        value = hackerGold.balanceOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41').toNumber() / 1000;
+
+        log("[0x2980] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1700000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0x29805ff5b946e7a7c5871c1fb071f740f767cf41',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x2980] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1700000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(50, voting / total * 100);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(50, voting / total * 100);
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(600000, value);
+
+        return true;
+    })
+});
+
+
+
+
+it('buy-apl-by-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] buy tokens [APL] for 400,000.000 HKG");
+
+
+    return virtualExchange.buy('APL', 400000000,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+       gas: 250000,
+    })
+
+    .then(function (txHash) {
+
+          return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function () {
+
+        dst1Balance = dstContract_APL.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x696b] => balance: " + dst1Balance.toFixed(3) + " APL");
+        assert.equal(400000000 , dst1Balance);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x696b] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(400000000000 , voting);
+
+        value = hackerGold.balanceOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber() / 1000;
+
+        log("[0x696b] => balance: " + value.toFixed(3) + " HKG");
+        assert.equal(1600000, value);
+
+        log ("[APL] => total: " + total + " votes");
+
+        veTokens = hackerGold.allowance('0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+                                          virtualExchange.address).toNumber() / 1000;
+        log("[0x696b] => VirtualExchange balance: " + veTokens.toFixed(3) + " HKG");
+        assert.equal(1600000 , veTokens);
+
+        availableSuply = dstContract_APL.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => available suply: " + availableSuply + " APL");
+
+
+        log("");
+        log(" Voting Summary: ");
+        log(" =============== ");
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d');
+
+        log ("[0x3a7e] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(30, voting / total * 100);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x29805ff5b946e7a7c5871c1fb071f740f767cf41');
+
+        log ("[0x2980] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(30, voting / total * 100);
+
+        total  = dstContract_APL.getPreferedQtySold();
+        voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3');
+
+        log ("[0x696b] => voting: " + voting + " votes - " + voting / total * 100 + "%");
+        assert.equal(40, voting / total * 100);
+
+        value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+        log("[APL] => collected: " + value.toFixed(3) + " HKG");
+        assert.equal(1000000, value);
+
+        return true;
+    })
+});
+
+
+
+it('roll-time-va-ends', function(){
+
+    return workbench.rollTimeTo('22-Dec-2016 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('roll-time-50%-available', function(){
+
+    return workbench.rollTimeTo('22-Feb-2017 14:00 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+it('submit-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0xcc49] ask to recieve 200,000.000 (20%) of the HKG collected");
+
+    return dstContract_APL.submitHKGProposal(200000000, "http://pastebin.com/raw/6e9PBTeP",
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       args = parsed.logs[0].args;
+
+       proposalId = args.id;
+       proposalValue = args.value;
+       proposalValue = proposalValue / 1000;
+
+       proposalTimeEnds = args.timeEnds;
+       proposalURL = args.url;
+       proposalSender = args.sender;
+
+       log("");
+       log("Proposal Submitted");
+       log("==================");
+
+       log("proposalId: "       + proposalId);
+       log("proposalValue: "    + proposalValue.toFixed(3));
+       log("proposalTimeEnds: " + proposalTimeEnds);
+       log("proposalURL: "      + proposalURL);
+       log("proposalSender: "   + proposalSender);
+
+
+       assert.equal(200000, proposalValue);
+
+       t1 = eventInfo.getNow().toNumber() + 60 * 60 * 24 * 10;
+       t2 = proposalTimeEnds;
+       assert.equal(t1, t2);
+
+       assert.equal(proposalURL,    "http://pastebin.com/raw/6e9PBTeP");
+       assert.equal(proposalSender, "0xcc49bea5129ef2369ff81b0c0200885893979b77");
+
+       proposal_1 = proposalId;
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(0, value);
+
+       return true;
+    })
+
+});
+
+
+
+it('object-by-vote-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] vote to object proposal 1");
+
+    return dstContract_APL.objectProposal(proposal_1,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       log_1 = parsed.logs[0];
+
+       total  = dstContract_APL.getPreferedQtySold();
+
+       log("\n");
+       log(log_1.event + ":");
+       log("============");
+
+       log("proposal.id: " + log_1.args.id);
+       log("voter: " + log_1.args.voter);
+       log("votes: " + log_1.args.votes + " share: " + (log_1.args.votes / total * 100).toFixed(2) + "%");
+
+       voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber();
+
+       assert.equal(proposal_1, log_1.args.id);
+       assert.equal(log_1.args.voter, "0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d");
+       assert.equal(log_1.args.votes, voting);
+
+       return true;
+    })
+
+});
+
+
+it('roll-time-proposal-redeem', function(){
+
+    return workbench.rollTimeTo('04-Mar-2017 14:01 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+it('redeem-proposal-1', function() {
+    log("");
+    log(" (!) Action: [0xcc49] collect 1,000.000 HKG value of proposal 1");
+
+    return dstContract_APL.redeemProposalFunds(proposal_1,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(1, parsed.logs.length);
+
+       args = parsed.logs[0].args;
+
+       assert.equal(dstContract_APL.address, args.from);
+       assert.equal("0xcc49bea5129ef2369ff81b0c0200885893979b77", args.to);
+       assert.equal(200000000, args.value);
+
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(200000, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(800000, value);
+
+       return true;
+    })
+
+});
+
+
+
+it('roll-time-for-new-proposal-submit', function(){
+
+    return workbench.rollTimeTo('08-Mar-2017 14:02 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+it('submit-proposal-2', function() {
+    log("");
+    log(" (!) Action: [0xcc49] ask to recieve 200,000.000 (20%) of the HKG collected");
+
+    return dstContract_APL.submitHKGProposal(200000000, "http://pastebin.com/raw/6e9PBTeP",
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+
+       args = parsed.logs[0].args;
+
+       proposalId = args.id;
+       proposalValue = args.value;
+       proposalValue = proposalValue / 1000;
+
+       proposalTimeEnds = args.timeEnds;
+       proposalURL = args.url;
+       proposalSender = args.sender;
+
+       log("");
+       log("Proposal Submitted");
+       log("==================");
+
+       log("proposalId: "       + proposalId);
+       log("proposalValue: "    + proposalValue.toFixed(3));
+       log("proposalTimeEnds: " + proposalTimeEnds);
+       log("proposalURL: "      + proposalURL);
+       log("proposalSender: "   + proposalSender);
+
+
+       assert.equal(200000, proposalValue);
+
+       t1 = eventInfo.getNow().toNumber() + 60 * 60 * 24 * 10;
+       t2 = proposalTimeEnds;
+       assert.equal(t1, t2);
+
+       assert.equal(proposalURL,    "http://pastebin.com/raw/6e9PBTeP");
+       assert.equal(proposalSender, "0xcc49bea5129ef2369ff81b0c0200885893979b77");
+
+       proposal_2 = proposalId;
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(200000, value);
+
+       return true;
+    })
+
+});
+
+
+it('object-by-vote-proposal-2-voter-3a7e', function() {
+    log("");
+    log(" (!) Action: [0x3a7e] vote to object proposal 1");
+
+    return dstContract_APL.objectProposal(proposal_2,
+    {
+       from : '0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       log_1 = parsed.logs[0];
+
+       total  = dstContract_APL.getPreferedQtySold();
+
+       log("\n");
+       log(log_1.event + ":");
+       log("============");
+
+       log("proposal.id: " + log_1.args.id);
+       log("voter: " + log_1.args.voter);
+       log("votes: " + log_1.args.votes + " share: " + (log_1.args.votes / total * 100).toFixed(2) + "%");
+
+       voting = dstContract_APL.votingRightsOf('0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d').toNumber();
+
+       assert.equal(proposal_2, log_1.args.id);
+       assert.equal(log_1.args.voter, "0x3a7e663c871351bbe7b6dd006cb4a46d75cce61d");
+       assert.equal(log_1.args.votes, voting);
+
+       return true;
+    })
+
+});
+
+
+it('object-by-vote-proposal-2-voter-696b', function() {
+    log("");
+    log(" (!) Action: [0x696b] vote to object proposal 1");
+
+    return dstContract_APL.objectProposal(proposal_2,
+    {
+       from : '0x696ba93ef4254da47ff05b6caa88190db335f1c3',
+       gas : 450000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       log_1 = parsed.logs[0];
+
+       total  = dstContract_APL.getPreferedQtySold();
+
+       log("\n");
+       log(log_1.event + ":");
+       log("============");
+
+       log("proposal.id: " + log_1.args.id);
+       log("voter: " + log_1.args.voter);
+       log("votes: " + log_1.args.votes + " share: " + (log_1.args.votes / total * 100).toFixed(2) + "%");
+
+       voting = dstContract_APL.votingRightsOf('0x696ba93ef4254da47ff05b6caa88190db335f1c3').toNumber();
+
+       assert.equal(proposal_2, log_1.args.id);
+       assert.equal(log_1.args.voter, "0x696ba93ef4254da47ff05b6caa88190db335f1c3");
+       assert.equal(log_1.args.votes, voting);
+
+       totalObjected = dstContract_APL.getProposalObjectionByIndex(1);
+
+       log("");
+       log("Proposal objected: " + totalObjected / total * 100 + "%");
+
+       return true;
+    })
+
+});
+
+
+
+it('roll-time-proposal-redeem', function(){
+
+    return workbench.rollTimeTo('18-Mar-2017 14:03 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+it('redeem-proposal-2', function() {
+    log("");
+    log(" (!) Action: [0xcc49] collect 200,000.000 HKG value of proposal 2");
+
+    return dstContract_APL.redeemProposalFunds(proposal_2,
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(0, parsed.logs.length);
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(200000, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(800000, value);
+
+       return true;
+    })
+
+});
+
+
+//
+//  [X] Action: [0xcc49] collect all the rest of HKG before 6 months over
+//
+
+it('collect-all-the-rest-funds-before-time', function() {
+    log("");
+    log(" [X] Action: [0xcc49] collect all the rest of HKG before 6 months over");
+
+    return dstContract_APL.getAllTheFunds(
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(0, parsed.logs.length);
+
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(200000, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(800000, value);
+
+       return true;
+    })
+
+});
+
+
+it('roll-time-for-total-redeem', function(){
+
+    return workbench.rollTimeTo('22-June-2017 14:04 UTC+00')
+    .then(function(contract) { printDate(); return true; });
+});
+
+
+
+//
+//  [X] Action: [0xdedb] collect all the rest of HKG by non executive
+//
+
+it('collect-all-the-rest-funds-before-time', function() {
+    log("");
+    log(" [X] Action: [0xdedb] collect all the rest of HKG by non executive");
+
+    return dstContract_APL.getAllTheFunds(
+    {
+       from : '0xdedb49385ad5b94a16f236a6890cf9e0b1e30392',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(0, parsed.logs.length);
+
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xdedb49385ad5b94a16f236a6890cf9e0b1e30392').toNumber() / 1000;
+
+       log("[0xdedb] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(0, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(800000, value);
+
+       return true;
+    })
+
+});
+
+
+it('collect-all-the-rest-funds', function() {
+    log("");
+    log(" (!) Action: [0xcc49] collect all the rest of HKG");
+
+    return dstContract_APL.getAllTheFunds(
+    {
+       from : '0xcc49bea5129ef2369ff81b0c0200885893979b77',
+       gas : 350000,
+    })
+
+    .then(function (txHash) {
+
+        return workbench.waitForReceipt(txHash);
+    })
+
+    .then(function (parsed) {
+
+       assert.equal(1, parsed.logs.length);
+
+       args = parsed.logs[0].args;
+
+       assert.equal(dstContract_APL.address, args.from);
+       assert.equal("0xcc49bea5129ef2369ff81b0c0200885893979b77", args.to);
+       assert.equal(800000000, args.value);
+
+       return true;
+    })
+
+    .then(function () {
+
+       value = hackerGold.balanceOf('0xcc49bea5129ef2369ff81b0c0200885893979b77').toNumber() / 1000;
+
+       log("[0xcc49] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(1000000, value);
+
+       value = hackerGold.balanceOf(dstContract_APL.address).toNumber() / 1000;
+
+       log("[APL] => balance: " + value.toFixed(3) + " HKG");
+       assert.equal(0, value);
+
+       return true;
+    })
+
+});
+
+
+
+});


### PR DESCRIPTION
RE: [adfb5cc](https://github.com/adklempner/virtual-accelerator/commit/adfb5cc4ad2201ab1c147c90f0e68c8f41692c85) "Replace assert with assert.equal where necessary"

Older tests were not using the assert() method correctly.
Ex: https://github.com/ether-camp/virtual-accelerator/blob/5c5cc40dd065f6279138d44901ae0776ec6755d1/test/dst-management/requesting-funds-test-4.js#L304

assert(a, b) is not the same as assert.equal(a, b)
The assert() function by itself simply returns whether the expression inside evaluates to true, it does not check for equality when it is passed two parameters.

When I replaced instances of assert() where there should be assert.equal(), it caused the test to fail, revealing that it was not checking for the correct value.

Ex: https://github.com/adklempner/virtual-accelerator/blob/adfb5cc4ad2201ab1c147c90f0e68c8f41692c85/test/dst-management/requesting-funds-test-5.js#L304